### PR TITLE
Properly escape message from istari server.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,11 +87,16 @@ let webviewHTML = `
 					case 'appendText': {
 						const mainText = document.getElementById('main_text');
 						if (mainText) {
-// console.log(message.text);
-mainText.innerHTML += "<hr><pre>" + message.text.replace(/\\n(\s*)/g, function(_, spaces) {
-// console.log('spaces', spaces, 'end');
-    return "<br>" + spaces.replace(/ /g, "&nbsp;");
-}) + "</pre>";						}
+							const new_hr = document.createElement("hr");
+							const new_pre = document.createElement("pre");
+							m = message.text; 
+							// Optionally "Clean up" the message
+							// m = m.replace(/\\n(\=+)/g, "");
+							// m = m.replace(/\\n(\-+)/g, "");
+							new_pre.textContent = m.trim();
+							main_text.appendChild(new_hr);
+							main_text.appendChild(new_pre);
+						}
 						break;
 					}
 					case 'resetText': {


### PR DESCRIPTION
This patches fixes an issue when outputs from `istari` contains HTML escape sequences, output in the webview becomes mangled. It sets the `textContent` property instead of `innerHTML`, which escapes the string properly. 